### PR TITLE
Add Terms of Service page

### DIFF
--- a/src/Terms.jsx
+++ b/src/Terms.jsx
@@ -1,0 +1,30 @@
+import React from "react";
+import NavBar from "./components/NavBar.jsx";
+import Footer from "./components/Footer.jsx";
+
+export default function Terms() {
+  return (
+    <>
+      <NavBar />
+      <main className="max-w-3xl mx-auto px-6 py-12 prose prose-neutral">
+        <h1>Terms of Service</h1>
+        <p>
+          Welcome to DeepNet Solutions. By accessing or using our services, you agree to the terms outlined on this page. Please read them carefully.
+        </p>
+        <h2>Use of Our Services</h2>
+        <p>
+          Our content and tools are provided for your business use. Do not misuse them or attempt to disrupt our systems.
+        </p>
+        <h2>Liability</h2>
+        <p>
+          We work hard to keep our platform running smoothly, but we can’t guarantee it will always be perfect. DeepNet Solutions isn’t liable for losses that arise from using our website.
+        </p>
+        <h2>Updates</h2>
+        <p>
+          We may update these terms as our services evolve. If the changes are significant, we’ll let you know.
+        </p>
+      </main>
+      <Footer />
+    </>
+  );
+}

--- a/src/terms.jsx
+++ b/src/terms.jsx
@@ -1,0 +1,10 @@
+import React from "react";
+import ReactDOM from "react-dom/client";
+import Terms from "./Terms.jsx";
+import "./index.css";
+
+ReactDOM.createRoot(document.getElementById("root")).render(
+  <React.StrictMode>
+    <Terms />
+  </React.StrictMode>
+);

--- a/terms/index.html
+++ b/terms/index.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Terms of Service – DeepNet Solutions</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link href="https://fonts.googleapis.com/css2?family=Open+Sans:wght@400;600&family=Poppins:wght@500;600;700&display=swap" rel="stylesheet" />
+    <link rel="icon" type="image/svg+xml" href="/logo.svg" />
+  </head>
+  <body class="font-body bg-neutral-90 text-neutral-10">
+    <div id="root"></div>
+    <script type="module" src="/src/terms.jsx"></script>
+  </body>
+</html>

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,9 +1,18 @@
 import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
+import { resolve } from 'path';
 
 export default defineConfig({
   plugins: [react()],
   server: {
     open: true,
+  },
+  build: {
+    rollupOptions: {
+      input: {
+        main: resolve(__dirname, 'index.html'),
+        terms: resolve(__dirname, 'terms/index.html'),
+      },
+    },
   },
 });


### PR DESCRIPTION
## Summary
- create dedicated Terms of Service React page
- add an HTML entry point and mount script
- configure Vite for multi-page output

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68490281d4c483268e11ab8133dca7bb