### PR TITLE
Fix Router context on static pages

### DIFF
--- a/src/components/NewsHeroRSS.jsx
+++ b/src/components/NewsHeroRSS.jsx
@@ -117,10 +117,14 @@ export default function NewsHeroRSS() {
 
       {/* Fixed CTAs */}
       <div className="relative z-20 flex flex-col sm:flex-row gap-4 justify-center mb-6">
-        <a href={slide.link} target="_blank" rel="noopener noreferrer" className="btn-primary">
+        <a
+          href={slide.link}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="btn-secondary"
+        >
           Read Full Story
         </a>
-        <a href="/contact" className="btn-secondary">
         <a href="#contact" className="btn-primary">
           Free Consultation
         </a>

--- a/src/privacy.jsx
+++ b/src/privacy.jsx
@@ -1,10 +1,13 @@
 import React from "react";
 import ReactDOM from "react-dom/client";
+import { BrowserRouter } from "react-router-dom";
 import Privacy from "./pages/Privacy.jsx";
 import "./index.css";
 
 ReactDOM.createRoot(document.getElementById("root")).render(
   <React.StrictMode>
-    <Privacy />
+    <BrowserRouter>
+      <Privacy />
+    </BrowserRouter>
   </React.StrictMode>
 );

--- a/src/terms.jsx
+++ b/src/terms.jsx
@@ -1,10 +1,13 @@
 import React from "react";
 import ReactDOM from "react-dom/client";
+import { BrowserRouter } from "react-router-dom";
 import Terms from "./Terms.jsx";
 import "./index.css";
 
 ReactDOM.createRoot(document.getElementById("root")).render(
   <React.StrictMode>
-    <Terms />
+    <BrowserRouter>
+      <Terms />
+    </BrowserRouter>
   </React.StrictMode>
 );


### PR DESCRIPTION
## Summary
- wrap `Privacy` and `Terms` standalone pages with `BrowserRouter`
- correct CTA markup in `NewsHeroRSS` component

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68491cfd00fc8326bab0910401a55285